### PR TITLE
Respond to initial PRC comments

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -1,16 +1,16 @@
 #######
-Classes
+Concepts
 #######
 
-The diagram below shows an overview of the pedigree classes. Lines between classes indicate composition.
+The diagram below shows an overview of the pedigree concepts. Lines between concepts indicate composition.
 
 .. figure:: images/classes.png
-   :alt: Overview of classes
+   :alt: Overview of concepts
 
 Individual
 ==========
 
-The subject of a **Pedigree** is represented by an **Individual** class. This class intends to represent an individual person or patient who is a member of the pedigree being investigated.  
+The **Individual** concept represents an individual person or patient who is a member of the pedigree being investigated.
 
 .. list-table::
    :header-rows: 1
@@ -36,20 +36,21 @@ The subject of a **Pedigree** is represented by an **Individual** class. This cl
    * - age
      - 0..1
      - Age of the individual, can be either Age, Estimated Age (or Ontology Class), Age Range, and/or Gestational Age; See also `Phenopackets' TimeElement <https://phenopacket-schema.readthedocs.io/en/latest/time-element.html#rsttimeelement>`_.
-   * - raceEthnicityAncestry
+   * - populationDescriptors
      - 0..*
-     - Race, Ethnicity, or Ancestry of the individual; terms from the `Human Ancestry Ontology (HANCESTRO) <https://www.ebi.ac.uk/ols/ontologies/hancestro>`_ are recommended.
+     - Information about the individual's ancestry, ethnicity, race, tribe, etc.,; terms from the `Human Ancestry Ontology (HANCESTRO) <https://www.ebi.ac.uk/ols/ontologies/hancestro>`_ are recommended, but freetext must be supported
    * - deceased
      - 0..1
      - The presumed/accepted life status of the individual as of the pedigree collection date
    * - affected
      - 0..1
-     - Whether or not the individual is affected by the condition being investigated in this pedigree (``Pedigree.reason``)
+     - Whether or not the individual is affected
+
 
 Relationship
 ============
 
-The *Relationship* class defines the family relations in a pedigree.
+The *Relationship* concept represents the relationship that one individual has to another individual.
 
 .. list-table::
    :header-rows: 1
@@ -67,10 +68,11 @@ The *Relationship* class defines the family relations in a pedigree.
      - 1..1
      - Identifier of the relative ``Individual``; equivalent to the Biolink "object"
 
+
 Pedigree
 ========
 
-A clinical **Pedigree** is curated selection of information about a family, including the individuals, relationships between them, and relevant health conditions.
+A **Pedigree** is a set of individuals and the relationships between them.
 
 .. list-table::
    :header-rows: 1
@@ -90,9 +92,6 @@ A clinical **Pedigree** is curated selection of information about a family, incl
    * - relationships
      - 0..*
      - Collection of ``Relationship`` between the ``individuals`` who are the members of this pedigree
-   * - reason
-     - 0..1
-     - The reason for pedigree collection, a health condition of focus being investigated in the family; if any ``Individual`` has the ``affected`` property defined, it refers to this condition.
    * - status
      - 0..1
      - Status of the pedigree resource collection

--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -1,0 +1,25 @@
+################################################
+Implementations
+################################################
+
+.. toctree::
+   :maxdepth: 1
+
+
+Known Implementations
+========================
+
+The following systems have implemented the GA4GH Pedigree Standard:
+
+FHIR implementations:
+
+- `CSIRO Redcap Pedigree Plugin <https://github.com/aehrc/redcap_pedigree_editor>`_ (Open Source)
+- `Open Pedigree <https://github.com/phenotips/open-pedigree>`_ (Open Source)
+
+Phenopacket implementations:
+
+- In progress...
+
+
+Do you have an implementation to share? Make a pull request via GitHub to add it.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,9 @@ Welcome to the technical documentation for the GA4GH Pedigree Standard!
 
    introduction
    pedigree-model
-   classes
+   concepts
    working-with-model
+   kin
+   tooling
+   implementations
    acknowledgements

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,47 +1,45 @@
 ###########################################
-Introduction to the GA4GH Pedigree Standard
+Introduction
 ###########################################
 
 .. toctree::
    :maxdepth: 1
 
-What is the GA4GH Pedigree Standard
+
+The GA4GH Pedigree Standard
 ======
 
 .. _reference 1:
 
-The GA4GH Pedigree Standard allows for the computable exchange of family health history as well as representation of larger, more complex families. The collection of specific clinical or genetic data is outside the scope of this deliverable, and would instead be handled by other formats and references to individuals within the pedigree representation.
+The GA4GH Pedigree Standard allows for the computable exchange of family structure and relationships for family health history and pedigree use cases. This involves the use of the Kinship Ontology to structure the relationships between individuals and allow for inference and computation.
 
-How did the Pedigree Standard Come About
-======
-
-The need for high quality, unambiguous, computable pedigree and family information is critical for scaling genomic analysis to larger, complex families. Pedigree data is currently represented in heterogeneous formats that frequently result in the use of lowest-common-denominator formats (e.g., PED) or custom JSON formats for data transfer. The HL7 FHIR standard core data models do not support pedigrees, but there is a draft extension to support genomic pedigrees that should be evaluated and potentially extended by the GA4GH. Standardizing the way systems represent family structure will allow patients to share this information more easily between healthcare systems and help software tools to use this information to improve genome analysis and diagnosis. 
-
-We asked our stakeholders about their use of family health history and pedigree data - How are you using it? How is it stored? What do you wish you could do with your data that you currently can't? The results of the survey can be `found here <https://docs.google.com/presentation/d/17r-WyVEpl57i0wxnJcgTkmuWclQovMRKkgqJrkWC4Yo/edit?usp=sharing>`_. A significant percentage of respondents were using a non-computable or non-interoperable format, and there was no common tool or format with which they intended to import or export data. Importantly, 57% of respondents were experiencing challenges with standardization, including lack of computability and integration with analysis tools, and inability to represent complex families and share data easily.
-
-Why PED is Not Enough
-======
-
-The `PED format <https://zzz.bwh.harvard.edu/plink/data.shtml>`_ is a simple text file with 6 columns - IDs, a binary sex field, the phenotype (singular) and SNP genotypes. You can represent a basic parent-child trio, and that may cover a lot of use cases. However, you can't represent twins, things like adoption or donors, pregnancy, vital status, multiple phenotypes and data provenance. All of this type of data is important for genetic counseling and risk assessments where richer representations of relationships are valuable.
-
-The GA4GH Pedigree Standard will natively incorporate PED to enable interoperability with legacy tools.
-
-Example Use Cases
-======
-
-A full listing of the use cases that informed development can be `reviewed here <https://docs.google.com/document/d/1i__95wmm3EpVytRD2gngFAXPhUajK2knWOtuHT9r8W8/edit?usp=sharing>`_.
-
-* Diagnostic genomic testing across a range of rare disease groups, with de-identified data from unsolved patients progressing into discovery research (data from solved cases also stored in research environment). Majority of testing undertaken as singletons, <5% as trios, other family configurations extremely rare (parent/child duo, sib pair, half-sib pair, quad). Pedigree information is required to inform clinical and research genomic data analysis.
-* Seamlessly share collected clinical and family health history information with bioinformatics systems and research environments (or other services) to unambiguously document relationships between sequenced individuals to support joint calling of variants and filtering of variants based on segregation, as well as describing wider family history (re: non-sequenced individuals).
-* Using family health history, genotype, and phenotype results of a patient or relative, to determine if the patient needs further testing or sequence analysis, and/or if a relative needs the same
-* It is difficult to predict all of the secondary uses of this information and so having it in a programmatic standard that people can consume across a number of resources in both a format for analysis as well as for building algorithms and tools over would be of high utility.
-* Link multiple individuals within same pedigree.
-* Describe multiple phenotypic/diagnostic/genetic features per individual.
-* Robustly represent relationships necessary for counseling (e.g., adoption), risk assessment (e.g., infertility, miscarriage, health history), and assisted reproduction (e.g., IVF, MRT).
+The collection of specific clinical or genetic data is handled by other formats and references to individuals within the pedigree representation.
 
 .. figure:: images/pedigree-ecosystem-diagram-v2.png
    :alt: The GA4GH Pedigree Ecosystem
-The GA4GH Pedigree Ecosystem
+
+
+Motivation
+======
+
+The need for high quality, unambiguous, computable pedigree and family information is critical for scaling genomic analysis to larger, complex families. Pedigree data is currently represented in heterogeneous formats that frequently result in the use of lowest-common-denominator formats (e.g., PED) or custom JSON formats for data transfer. The HL7 FHIR standard core data models do not support pedigrees, but there is a draft extension to support genomic pedigrees for a single, fixed proband patient.
+
+By standardizing the way systems represent family structure, patients will be able to share this information more easily between healthcare systems, and software tools will be better able to use this information to improve genome analysis and diagnosis.
+
+We asked our stakeholders about their use of family health history and pedigree data - How are you using it? How is it stored? What do you wish you could do with your data that you currently can't? The results of the survey can be `found here <https://docs.google.com/presentation/d/17r-WyVEpl57i0wxnJcgTkmuWclQovMRKkgqJrkWC4Yo/edit?usp=sharing>`_. A significant percentage of respondents were using a non-computable or non-interoperable format, and there was no common tool or format with which they intended to import or export data. Importantly, 57% of respondents were experiencing challenges with standardization, including lack of computability and integration with analysis tools, and inability to represent complex families and share data easily.
+
+A full listing of the use cases that informed development can be `reviewed here <https://docs.google.com/document/d/1i__95wmm3EpVytRD2gngFAXPhUajK2knWOtuHT9r8W8/edit?usp=sharing>`_.
+
+
+Alternatives
+======
+
+The `PED format <https://zzz.bwh.harvard.edu/plink/data.shtml>`_ is a simple text file with 6 columns - IDs, a binary sex field, the phenotype (singular) and SNP genotypes. It can represent parent-child relationships only. It is unable to communicate twins, adoption or donors, pregnancy, vital status, multiple phenotypes and data provenance. All of this type of data is important for genetic counseling and risk assessments where richer representations of relationships are valuable.
+
+The HL7 `FamilyMemberHistory resource <https://www.hl7.org/fhir/familymemberhistory.html>`_ and `FamilyMemberHistory-genetic profile <https://build.fhir.org/familymemberhistory-genetic.html>`_ allow for capturing a proband's family health history. All data and relationships are relative to that single proband and are in the context of a single patient. This limits its use for representing a complete pedigree for a family.
+
+The `HL7 FHIR FamilyMember ValueSet <https://terminology.hl7.org/3.1.0/ValueSet-v3-FamilyMember.html>`_ is a taxonomy, not an ontology, which limits its utility. It is also Anglo-centric in its construction, which limits the global adoption, for example, there aren't equivalent terms for "aunt" and "uncle". By creating the Kinship Ontology, we were able to define deeper semantics between relationships, allowing these terms to be used for inference or validation.
+
 
 The Common Dataset for FHH
 ======
@@ -51,6 +49,18 @@ The collection and use of family health histories span medical activities from g
 `Common Dataset Document <https://docs.google.com/document/d/1GQRd5jeZeB5qhHclLZxDe6kPD173bXWGYlTsmCbTeuI/edit?usp=sharing>`_
 
 This work was inspired by the efforts of the Personalized Health Care Workgroup of the American Health Information Community, which first released its recommendation on a core family health history (FHH) minimum data set on October 25, 2007. A `peer-reviewed paper <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2585527/>`_ was published in December 2008.
+
+
+Example Use Cases
+======
+
+* Robustly represent relationships necessary for counseling (e.g., adoption), risk assessment (e.g., infertility, miscarriage, health history), and assisted reproduction (e.g., IVF, MRT)
+* Diagnostic genomic testing across a range of rare disease groups, with de-identified data from unsolved patients progressing into discovery research (data from solved cases also stored in research environment). Majority of testing undertaken as singletons, <5% as trios, other family configurations extremely rare (parent/child duo, sib pair, half-sib pair, quad). Pedigree information is required to inform clinical and research genomic data analysis.
+* Seamlessly share collected clinical and family health history information with bioinformatics systems and research environments (or other services) to unambiguously document relationships between sequenced individuals to support joint calling of variants and filtering of variants based on segregation, as well as describing wider family history (re: non-sequenced individuals).
+* Using family health history, genotype, and phenotype results of a patient or relative, to determine if the patient needs further testing or sequence analysis, and/or if a relative needs the same
+* Link multiple individuals within same pedigree.
+* It is difficult to predict all of the secondary uses of this information and so having it in a programmatic standard that people can consume across a number of resources in both a format for analysis as well as for building algorithms and tools over would be of high utility.
+
 
 Requirement Levels
 ======
@@ -70,10 +80,3 @@ Optional
 A field is truly optional. This category can be applied to fields that are only useful for a certain type of data. For
 instance, the Proband ID and Type field is only required when the pedigree is used to focus on heritable risk for a specific person in the pedigree. For other use cases such as research, a Proband type may be needed.
 
-Brief Explainer of Protobuf and HL7 FHIR
-======
-Depending on how you choose to work with the GA4GH Pedigree model, you may be working with different formats.
-
-*If using the Pedigree model in the context of Phenopackets*: Phenopackets schema uses protobuf, an exchange format developed in 2008 by Google. It is recommended to review the `Wikipedia page on Protobuf <https://en.wikipedia.org/wiki/Protocol_Buffers>`_ and to `Google’s documentation <https://developers.google.com/protocol-buffers/>`_ for details. This page intends to get curious readers who are unfamiliar with protobuf up to speed with the main aspects of this technology, but it is not necessary to understand protobuf to use the phenopacket or pedigree schemas. Learn more about the Phenopackets `here <https://phenopacket-schema.readthedocs.io/en/latest/index.html>`_, and the draft Phenopackets implementation of Pedigree `here <https://github.com/phenopackets/phenopacket-schema/blob/pedigree/src/main/proto/ga4gh/pedigree/v1/pedigree.proto>`_.
-
-*If using the Pedigree model in the context of HL7 FHIR*: Fast Health Interoperability Resources (FHIR) is a loosely defined base model describing things in healthcare (e.g. Patient, Specimen) and how they relate to each other, developed by Health Level 7 (HL7). The FHIR specification is completely technology agnostic. Thus, it does not depend on programming languages or include things like relational database schemas. It is up to the implementers to decide how to implement the data model (i.e. relational database, nosql database, etc) and RESTful API. To learn more about FHIR, we recommend you check out the following resources: `HL7.org <http://hl7.org/fhir/index.html>`_, `FHIR Basics <https://smilecdr.com/docs/tutorial_and_tour/fhir_basics.html#fhir-basics>`_, and this excellent `FHIR 101 Jupyter Notebook <https://github.com/NIH-NCPI/fhir-101>`_ developed by NIH Cloud-based Platform Interoperability (NCPI) Working Groups. Learn more about the Pedigree FHIR Implementation Guide `here <http://purl.org/ga4gh/pedigree-fhir-ig/index.html>`_.

--- a/docs/source/kin.rst
+++ b/docs/source/kin.rst
@@ -1,0 +1,16 @@
+################################################
+Kinship Ontology (KIN)
+################################################
+
+.. toctree::
+   :maxdepth: 1
+
+
+The Kinship Ontology
+========================
+
+`The Kinship Ontology (KIN) <https://github.com/GA4GH-Pedigree-Standard/family_history_terminology>`_ is a family relations ontology developed as part of the Global Alliance for Genomics and Health Pedigree Standard project. It allows using an OWL reasoner to automatically validate a family history graph and infer new relations.
+
+The latest version of the ontology can be found at: http://purl.org/ga4gh/kin.owl.
+
+The Ontology is open-source and managed in this GitHub repo: https://github.com/GA4GH-Pedigree-Standard/family_history_terminology

--- a/docs/source/pedigree-model.rst
+++ b/docs/source/pedigree-model.rst
@@ -31,7 +31,6 @@ Because of this inherent flexibility in the way that relationships can be descri
 5. Has extended relative relationships only when this is not implied by the previously-defined relationships, and they are directed downwards, with the ancestor as the individual and the descendant as the relative
 
 
-
 Examples
 ===========
 
@@ -43,30 +42,40 @@ The precise representation within the context of one of the standards, such as F
 Basic Trio
 ------------
 
-A basic family trio consists of one male parent, one female parent, and a child. This would be represented as a Pedigree with three Individuals and two parent-child Relationships:
+A basic family trio consists of one male parent, one female parent, and a proband child. This would be represented as a Pedigree with three Individuals and two parent-child Relationships:
+
+As a Phenopacket `GA4GHPedigree` message:
 
 .. code-block:: yaml
-
+  id: FAM1
+  narrative: A Phenopacket GA4GHPedigree of a trio with an affected child
+  date: 2022-06-23
   individuals:
-    -
-      id: MOTHER
-      sex: FEMALE
-    -
-      id: FATHER
-      sex: MALE
-    -
-      id: CHILD
-      sex: UNKNOWN
+    - id: 1
+      subject:
+        id: MOTHER
+        sex: FEMALE
+    - id: 2
+      subject:
+        id: FATHER
+        sex: MALE
+    - id: 3
+      subject:
+        id: CHILD
+        sex: UNKNOWN
   relationships:
-    -
-      individual: MOTHER
-      relationship: isBiologicalMotherOf
-      relative: CHILD
-    -
-      individual: FATHER
-      relationship: isBiologicalFatherOf
-      relative: CHILD
-
+    - individual_id: MOTHER
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: CHILD
+    - individual_id: FATHER
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: CHILD
+  index_patients:
+    - CHILD
 
 
 Twins
@@ -76,32 +85,42 @@ The relationship between twins (TWIN1 and TWIN2) can be represented by adding an
 
 .. code-block:: yaml
 
+  id: FAM2
+  narrative: A Phenopacket GA4GHPedigree of a couple with identical twins
+  date: 2022-06-23
   individuals:
-    -
-      id: MOTHER
-      sex: FEMALE
-    -
-      id: FATHER
-      sex: MALE
-    -
-      id: TWIN1
-      sex: UNKNOWN
-    -
-      id: TWIN2
-      sex: UNKNOWN
+    - id: 1
+      subject:
+        id: MOTHER
+        sex: FEMALE
+    - id: 2
+      subject:
+        id: FATHER
+        sex: MALE
+    - id: 3
+      subject:
+        id: TWIN1
+        sex: UNKNOWN
+    - id: 4
+      subject:
+        id: TWIN2
+        sex: UNKNOWN
   relationships:
-    -
-      individual: MOTHER
-      relationship: isBiologicalMotherOf
-      relative: CHILD
-    -
-      individual: FATHER
-      relationship: isBiologicalFatherOf
-      relative: CHILD
-    -
-      individual: TWIN1
-      relationship: isMonozygoticTwinOf
-      relative: TWIN2
+    - individual_id: MOTHER
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: TWIN1
+    - individual_id: FATHER
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: TWIN1
+    - individual_id: TWIN1
+      relation:
+        id: KIN:010
+        label: isMonozygoticMultipleBirthSiblingOf
+      relative_id: TWIN2
 
 
 The parent-child relationships for TWIN2 are not strictly necessary.
@@ -114,33 +133,43 @@ Adoption
 
 .. code-block:: yaml
 
-  individuals:
-    -
-      id: MOTHER
-      sex: FEMALE
-    -
-      id: BIOLOGICAL_MOTHER
-      sex: FEMALE
-    -
-      id: FATHER
-      sex: MALE
-    -
-      id: CHILD
-      sex: UNKNOWN
-  relationships:
-    -
-      individual: MOTHER
-      relationship: isAdoptiveParentOf
-      relative: CHILD
-    -
-      individual: BIOLOGICAL_MOTHER
-      relationship: isBiologicalMotherOf
-      relative: CHILD
-    -
-      individual: FATHER
-      relationship: isBiologicalFatherOf
-      relative: CHILD
 
+  id: FAM3
+  narrative: A Phenopacket GA4GHPedigree of a child with an adoptive mother
+  date: 2022-06-23
+  individuals:
+    - id: 1
+      subject:
+        id: MOTHER
+        sex: FEMALE
+    - id: 2
+      subject:
+        id: BIOLOGICAL_MOTHER
+        sex: FEMALE
+    - id: 3
+      subject:
+        id: FATHER
+        sex: MALE
+    - id: 4
+      subject:
+        id: CHILD
+        sex: UNKNOWN
+  relationships:
+    - individual_id: MOTHER
+      relation:
+        id: KIN:022
+        label: isAdoptiveParentOf
+      relative_id: CHILD
+    - individual_id: BIOLOGICAL_MOTHER
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: CHILD
+    - individual_id: FATHER
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: CHILD
 
 
 IVF
@@ -148,32 +177,42 @@ IVF
 
 .. code-block:: yaml
 
+  id: FAM4
+  narrative: A Phenopacket GA4GHPedigree of a child with an egg donor, gestational carrier, and biological father
+  date: 2022-06-23
   individuals:
-    -
-      id: MOTHER
-      sex: FEMALE
-    -
-      id: SURROGATE
-      sex: FEMALE
-    -
-      id: FATHER
-      sex: MALE
-    -
-      id: CHILD
-      sex: UNKNOWN
+    - id: 1
+      subject:
+        id: MOTHER
+        sex: FEMALE
+    - id: 2
+      subject:
+        id: SURROGATE
+        sex: FEMALE
+    - id: 3
+      subject:
+        id: FATHER
+        sex: MALE
+    - id: 4
+      subject:
+        id: CHILD
+        sex: UNKNOWN
   relationships:
-    -
-      individual: MOTHER
-      relationship: isOvumDonorOf
-      relative: CHILD
-    -
-      individual: SURROGATE
-      relationship: isGestationalCarrierOf
-      relative: CHILD
-    -
-      individual: FATHER
-      relationship: isBiologicalFatherOf
-      relative: CHILD
+    - individual_id: MOTHER
+      relation:
+        id: KIN:038
+        label: isOvumDonorOf
+      relative_id: CHILD
+    - individual_id: SURROGATE
+      relation:
+        id: KIN:005
+        label: isGestationalCarrierOf
+      relative_id: CHILD
+    - individual_id: FATHER
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: CHILD
 
 
 Complete cancer family
@@ -187,157 +226,202 @@ Complete cancer family
 
 .. code-block:: yaml
 
-  index:
-    -
-      id: 14
-      type: proband
+  id: FAM5
+  narrative: A Phenopacket GA4GHPedigree of a classic BRCA1 pedigree
+  date: 2022-06-23
   individuals:
-    -
-      id: 1
-      sex: MALE
-      deceased: true
-    -
-      id: 2
-      sex: FEMALE
-      deceased: true
-    -
-      id: 3
-      sex: MALE
-      deceased: true
-    -
-      id: 4
-      sex: FEMALE
-      deceased: true
-      attributes:
-        -
-          term: Ovarian cancer
-          ageAtDiagnosis: 49 yrs
-    -
-      id: 5
-      sex: FEMALE
-    -
-      id: 6
-      sex: FEMALE
-    -
-      id: 7
-      sex: MALE
-    -
-      id: 8
-      sex: FEMALE
-      attributes:
-        -
-          term: Breast cancer
-          ageAtDiagnosis: 42 yrs
-    -
-      id: 9
-      sex: MALE
-    -
-      id: 10
-      sex: FEMALE
-    -
-      id: 11
-      sex: FEMALE
-      attributes:
-        -
-          term: Ovarian cancer
-          ageAtDiagnosis: 53 yrs
-    -
-      id: 12
-      sex: FEMALE
-    -
-      id: 13
-      sex: MALE
-    -
-      id: 14
-      sex: FEMALE
-    -
-      id: 15
-      sex: FEMALE
-      attributes:
-        -
-          term: Breast cancer
-          ageAtDiagnosis: 38 yrs
+    - id: 1
+      subject:
+        id: 1
+        sex: MALE
+        vital_status: DECEASED
+    - id: 2
+      subject:
+        id: 2
+        sex: FEMALE
+        vital_status: DECEASED
+    - id: 3
+      subject:
+        id: 3
+        sex: MALE
+        vital_status: DECEASED
+    - id: 4
+      subject:
+        id: 4
+        sex: FEMALE
+        vital_status: DECEASED
+        diseases:
+          - term:
+              id:
+              label: Ovarian cancer
+            onset:
+              age: P49Y
+    - id: 5
+      subject:
+        id: 5
+        sex: FEMALE
+    - id: 6
+      subject:
+        id: 6
+        sex: FEMALE
+    - id: 7
+      subject:
+        id: 7
+        sex: MALE
+    - id: 8
+      subject:
+        id: 8
+        sex: FEMALE
+        diseases:
+          - term:
+              id:
+              label: Breast cancer
+            onset:
+              age: P42Y
+    - id: 9
+      subject:
+        id: 9
+        sex: MALE
+    - id: 10
+      subject:
+        id: 10
+        sex: FEMALE
+    - id: 11
+      subject:
+        id: 11
+        sex: FEMALE
+        diseases:
+          - term:
+              id:
+              label: Ovarian cancer
+            onset:
+              age: P53Y
+    - id: 12
+      subject:
+        id: 12
+        sex: FEMALE
+    - id: 13
+      subject:
+        id: 13
+        sex: MALE
+    - id: 14
+      subject:
+        id: 14
+        sex: FEMALE
+    - id: 15
+      subject:
+        id: 15
+        sex: FEMALE
+        diseases:
+          - term:
+              id:
+              label: Breast cancer
+            onset:
+              age: P38Y
   relationships:
-    -
-      individual: 1
-      relationship: isBiologicalFatherOf
-      relative: 5
-    -
-      individual: 2
-      relationship: isBiologicalMotherOf
-      relative: 5
-    -
-      individual: 1
-      relationship: isBiologicalFatherOf
-      relative: 6
-    -
-      individual: 2
-      relationship: isBiologicalMotherOf
-      relative: 6
-    -
-      individual: 1
-      relationship: isBiologicalFatherOf
-      relative: 7
-    -
-      individual: 2
-      relationship: isBiologicalMotherOf
-      relative: 7
-    -
-      individual: 3
-      relationship: isBiologicalFatherOf
-      relative: 8
-    -
-      individual: 4
-      relationship: isBiologicalMotherOf
-      relative: 8
-    -
-      individual: 3
-      relationship: isBiologicalFatherOf
-      relative: 9
-    -
-      individual: 4
-      relationship: isBiologicalMotherOf
-      relative: 9
-    -
-      individual: 3
-      relationship: isBiologicalFatherOf
-      relative: 11
-    -
-      individual: 4
-      relationship: isBiologicalMotherOf
-      relative: 11
-    -
-      individual: 3
-      relationship: isBiologicalFatherOf
-      relative: 12
-    -
-      individual: 4
-      relationship: isBiologicalMotherOf
-      relative: 12
-    -
-      individual: 7
-      relationship: isBiologicalFatherOf
-      relative: 13
-    -
-      individual: 8
-      relationship: isBiologicalMotherOf
-      relative: 13
-    -
-      individual: 9
-      relationship: isBiologicalFatherOf
-      relative: 14
-    -
-      individual: 10
-      relationship: isBiologicalMotherOf
-      relative: 14
-    -
-      individual: 7
-      relationship: isBiologicalFatherOf
-      relative: 15
-    -
-      individual: 8
-      relationship: isBiologicalMotherOf
-      relative: 15
+    - individual_id: 1
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 5
+    - individual_id: 2
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 5
+    - individual_id: 1
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 6
+    - individual_id: 2
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 6
+    - individual_id: 1
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 7
+    - individual_id: 2
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 7
+    - individual_id: 3
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 8
+    - individual_id: 4
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 8
+    - individual_id: 3
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 9
+    - individual_id: 4
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 9
+    - individual_id: 3
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 11
+    - individual_id: 4
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 11
+    - individual_id: 3
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 12
+    - individual_id: 4
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 12
+    - individual_id: 7
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 13
+    - individual_id: 8
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 13
+    - individual_id: 9
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 14
+    - individual_id: 10
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 14
+    - individual_id: 7
+      relation:
+        id: KIN:028
+        label: isBiologicalFatherOf
+      relative_id: 15
+    - individual_id: 8
+      relation:
+        id: KIN:027
+        label: isBiologicalMotherOf
+      relative_id: 15
+  index_patients:
+    - 14
+
 
 
 

--- a/docs/source/pedigree-model.rst
+++ b/docs/source/pedigree-model.rst
@@ -10,59 +10,7 @@ Overview
 
 To support the interoperability of family health history data within and between existing standards (such as HL7 FHIR and Phenopackets), the GA4GH Clinical and PhenoTips Data Capture Workstream developed the Pedigree Conceptual Model.
 
-The Pedigree Conceptual Model defines core classes and their properties, and is based on the `A Recommendation for The Common Data Set for Family Health History <https://docs.google.com/document/d/1GQRd5jeZeB5qhHclLZxDe6kPD173bXWGYlTsmCbTeuI/edit>`_.
-
-
-
-Key Concepts
-=============
-
-The model defines three core classes:
-
-
-Individual
-------------
-
-A person or entity.
-
-- Individual id - required
-- Sex at birth - required
-- Gender
-- Name
-- DOB
-- Age / Age Range / Estimated Age / Gestational Age
-- REA - Concept - suggested list of concepts from HANCESTRO
-- Deceased
-- Disease/condition: code, onset, contributed to death
-- Affected: Y/N/?
-  - for backwards-compatibility with PED
-- Other risk-relevant observations
-
-
-Relationship
-------------
-
-A relationship that one individual has with another relative.
-
-- individual - required
-- relationship - required, coded using KIN terms
-- relative - required
-
-
-Pedigree
-------------
-
-A collection of information about related individuals and relationships between them.
-
-- ID - Required
-- Index patients (proband, consultand, first person tested positive for a particular condition/variant)
-  - Individual
-  - Type enum: Proband, Consultand, First Person Tested Positive
-- Completion status
-- Language
-- Narrative
-- Date collected/updated
-
+The Pedigree Conceptual Model defines core concepts and their properties, and is based on the `A Recommendation for The Common Data Set for Family Health History <https://docs.google.com/document/d/1GQRd5jeZeB5qhHclLZxDe6kPD173bXWGYlTsmCbTeuI/edit>`_.
 
 
 Direction of Relationships
@@ -74,29 +22,14 @@ Symmetric relationships are those where both individuals share the same relation
 
 Non-symmetric relationships are those where the relationship that individual X has to individual Y is not the same as the relationship that individual Y has to individual X. For example, if individual X has relationship `isBiologicalParentOf` to individual Y, then individual Y has relationship `isBiologicalChildOf` individual X.
 
-Because of this inherent flexibility in the way that relationships can be described, we define the notion of a **minimum standard form** for describing a pedigree. A pedigree in minimum standard form:
+Because of this inherent flexibility in the way that relationships can be described, there is no single representation for a particular pedigree. However, pedigrees can be represented in a **reduced form**, in which implied relationships are excluded. A pedigree in reduced form:
+
 1. Has explicit parent-child relationships between all parents and their offspring, and they are directed downwards, with the parent as the individual and the child as the relative.
 2. Has sibling relationships only when this is not implied by having shared parents, and in the event of multiple siblings, all sibling relationships are defined relative to the same individual
 3. Defines all twin relationships relative to the same individual
 4. Has partnership relationships only when this is not implied by having shared children
-5. Has extended relative relationships only when this is not implied by the previously-defined relationships, and they are directed downwards, with the ancestor as the individual and the descendant as the relative.
+5. Has extended relative relationships only when this is not implied by the previously-defined relationships, and they are directed downwards, with the ancestor as the individual and the descendant as the relative
 
-
-
-Compatible standards
-====================
-
-Compatible standards provide an implementation guide for capturing and representing pedigree data in a manner that is compatible with this model.
-
-The representation of each core data element within each standard is summarized in :doc:`classes`.
-
-The current list of compatible standards are:
-
-Phenopackets
-  A Phenopacket implementation guide is currently underway. At the moment, an aligned implementation is defined on a branch of the Phenopacket repository: https://github.com/phenopackets/phenopacket-schema/blob/pedigree/src/main/proto/ga4gh/pedigree/v1/pedigree.proto
-
-HL7 FHIR
-  The FHIR Implementation Guide is here: https://github.com/GA4GH-Pedigree-Standard/pedigree-fhir-ig
 
 
 Examples

--- a/docs/source/tooling.rst
+++ b/docs/source/tooling.rst
@@ -1,0 +1,35 @@
+################################################
+Tooling
+################################################
+
+.. toctree::
+   :maxdepth: 1
+
+
+
+Pedigree Tools
+========================
+
+`Pedigree-tools <https://github.com/GA4GH-Pedigree-Standard/pedigree-tools>`_ is a library for supporting the conversion of pedigree data between various file formats.
+
+It can currently support importing from the following formats:
+
+- PED/Linkage
+- GEDCOM (Cyrillic)
+- BOADICEA
+
+In can currently export into the following formats:
+
+- PED/Linkage
+
+This tool is available at the following GitHub repository: https://github.com/GA4GH-Pedigree-Standard/pedigree-tools
+
+
+Pedigree Validator
+========================
+
+`Pedigree Validator <https://github.com/GA4GH-Pedigree-Standard/pedigree-validator>`_ is a simple command line application that shows how validation of a FHIR pedigree file can be implemented using the HAPI FHIR libraries and the artifacts produced by the FHIR implementation guide.
+
+It also shows how an OWL reasoner can be used to implement additional validation based on the KIN ontology.
+
+The application is available at the following GitHub repository: https://github.com/GA4GH-Pedigree-Standard/pedigree-validator

--- a/docs/source/working-with-model.rst
+++ b/docs/source/working-with-model.rst
@@ -1,60 +1,43 @@
 ################################################
-Working with the Pedigree Model
+Using the Pedigree Model
 ################################################
 
 .. toctree::
    :maxdepth: 1
 
-Kinship Ontology (KIN)
-========================
 
-The Kinship Ontology (KIN) is a family relations ontology developed as part of the Global Alliance for Genomics and Health Pedigree Standard project. It allows using an OWL reasoner to automatically validate a family history graph and infer new relations.
+Compatible standards
+====================
 
-The latest version of the ontology can be found at: http://purl.org/ga4gh/kin.owl.
+The GA4GH Pedigree standard is a conceptual model and recommendations for transferring family history and pedigree data. It is not a standalone data format, but is intended to be implemented by compatible standards to facilitate the transfer and interoperability of this data.
 
-The Ontology is open-source and managed in this GitHub repo: https://github.com/GA4GH-Pedigree-Standard/family_history_terminology
+Compatible standards provide an implementation guide for capturing and representing pedigree data in a manner that is compatible with this model.
 
+The representation of each core concept within each standard is summarized in :doc:`concepts`.
 
-Pedigree Tools
-========================
+The current list of compatible standards are:
 
-Pedigree-tools is a library for supporting the conversion of pedigree data between various file formats.
-
-It can currently support importing from the following formats:
-
-- GA4GH Pedigree
-- PED/Linkage
-- GEDCOM (Cyrillic)
-- BOADICEA
-
-In can currently export into the following formats:
-
-- GA4GH Pedigree
-- PED/Linkage
-
-This tool is available at the following GitHub repository: https://github.com/GA4GH-Pedigree-Standard/pedigree-tools
+* Phenopackets
+* HL7 FHIR
 
 
-Pedigree Validator
-========================
+Phenopackets
+===================
 
-This is a simple command line application that shows how validation of a FHIR pedigree file can be implemented using the HAPI FHIR libraries and the artifacts produced by the FHIR implementation guide.
+`The Phenopackets “Implementation Guide” <https://github.com/phenopackets/phenopacket-schema/blob/pedigree/src/main/proto/ga4gh/pedigree/v1/pedigree.proto>`_ - an implementation of the GA4GH pedigree spec which is partly composed of phenopacket-schema messages. It is not ‘part’ of the Phenopackets spec, but sits in its own org.ga4gh.pedigree namespace.
 
-It also shows how an OWL reasoner can be used to implement additional validation based on the KIN ontology.
+For tools like Exomiser, it is possible to convert to PED format using pedigree-tools and ingest via a Phenopacket.
 
-The application is available at the following GitHub repository: https://github.com/GA4GH-Pedigree-Standard/pedigree-validator
+Phenopackets schema uses protobuf, an exchange format developed in 2008 by Google. It is recommended to review the `Wikipedia page on Protobuf <https://en.wikipedia.org/wiki/Protocol_Buffers>`_ and to `Google’s documentation <https://developers.google.com/protocol-buffers/>`_ for details. This page intends to get curious readers who are unfamiliar with protobuf up to speed with the main aspects of this technology, but it is not necessary to understand protobuf to use the phenopacket or pedigree schemas.
+
+Learn more about the Phenopackets `here <https://phenopacket-schema.readthedocs.io/en/latest/index.html>`_.
 
 
-Example Implementations
-========================
+HL7 FHIR
+=============
 
-The following systems have implemented the GA4GH Pedigree Standard:
+`The Pedigree FHIR Implementation Guide <http://purl.org/ga4gh/pedigree-fhir-ig/index.html>`_.
 
-FHIR implementations:
+Fast Health Interoperability Resources (FHIR) is a loosely defined base model describing things in healthcare (e.g. Patient, Specimen) and how they relate to each other, developed by Health Level 7 (HL7). The FHIR specification is completely technology agnostic. Thus, it does not depend on programming languages or include things like relational database schemas. It is up to the implementers to decide how to implement the data model (i.e. relational database, nosql database, etc) and RESTful API.
 
-- `CSIRO Redcap Pedigree Plugin <https://github.com/aehrc/redcap_pedigree_editor>`_ (Open Source)
-- `Open Pedigree <https://github.com/phenotips/open-pedigree>`_ (Open Source)
-
-Phenopacket implementations:
-
-- In progress...
+To learn more about FHIR, we recommend you check out the following resources: `HL7.org <http://hl7.org/fhir/index.html>`_, `FHIR Basics <https://smilecdr.com/docs/tutorial_and_tour/fhir_basics.html#fhir-basics>`_, and this excellent `FHIR 101 Jupyter Notebook <https://github.com/NIH-NCPI/fhir-101>`_ developed by NIH Cloud-based Platform Interoperability (NCPI) Working Groups.


### PR DESCRIPTION
* Updated and reorganized explanatory text based on PRC comments
* Updated examples to align with updated Phenopacket implementation guide
* Changed raceEthnicityAncetry to populationDescriptors
* Remove Pedigree.reason as it isn't used anymore